### PR TITLE
[Build] Corrige fluxo do entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,8 +5,17 @@ cd project/orm_fonte && poetry run alembic upgrade head
 cd ../orm_alvo && poetry run alembic upgrade head
 cd /app
 
-# Inicia a aplicação
-poetry run uvicorn --host 0.0.0.0 --port 8000 project.api:app
+# Inicia a aplicação (em background)
+poetry run uvicorn --host 0.0.0.0 --port 8000 project.api:app & APP_PID=$!
 
-# Cria os dados fakes no banco de dados alvo e executa o pipeline
+# Garente que a aplicação esteja pronta para receber requisições
+sleep 10
+
+# Cria os dados fakes no banco de dados alvo e executa o pipeline (depende da aplicação estar rodando)
 poetry run python -m project.main
+
+# Para a aplicação (em background)
+kill $APP_PID
+
+# Executa novamente a aplicação (em foreground)
+poetry run uvicorn --host 0.0.0.0 --port 8000 project.api:app


### PR DESCRIPTION
Esse pr garante que o entrypoint seja executado corretamente, subindo a aplicação em background para executar o pipeline e depois subindo novamente para em foreground para aceitar requisições.